### PR TITLE
Increase heatmap figure size.

### DIFF
--- a/science_submission/Snakefile
+++ b/science_submission/Snakefile
@@ -160,6 +160,7 @@ rule heatmap_lit:
             cmap='viridis',
             cbar_kws={'label': 'Normalized Read Counts\n(z-score)'},
             rasterized=False,
+            figsize=(20, 20),
         )
 
         ax = g.ax_heatmap
@@ -195,6 +196,7 @@ rule heatmap_ptrap:
             cmap='viridis',
             cbar_kws={'label': 'Normalized Read Counts\n(z-score)'},
             rasterized=False,
+            figsize=(20, 20),
         )
 
         ax = g.ax_heatmap


### PR DESCRIPTION
For the new literature genes and protein trap genes, there are some many
genes I needed to increase the size of the plots. Now fontsizes are
going to be a little small if re-scaled.

### What does it do?
- Increase figure size for heatmaps to 20x20